### PR TITLE
register unit to namespace

### DIFF
--- a/{{ cookiecutter.repo_name }}/plugins/{{ cookiecutter.plugin_name }}/{{ cookiecutter.plugin_name }}.cpp
+++ b/{{ cookiecutter.repo_name }}/plugins/{{ cookiecutter.plugin_name }}/{{ cookiecutter.plugin_name }}.cpp
@@ -31,5 +31,5 @@ void {{ cookiecutter.plugin_name }}::next(int nSamples)
 PluginLoad({{ cookiecutter.plugin_name }}UGens) {
     // Plugin magic
     ft = inTable;
-    registerUnit<{{ cookiecutter.plugin_name }}::{{ cookiecutter.plugin_name }}>(ft, "{{ cookiecutter.plugin_name }}");
+    registerUnit<{{ cookiecutter.project_namespace }}::{{ cookiecutter.plugin_name }}>(ft, "{{ cookiecutter.plugin_name }}");
 }


### PR DESCRIPTION
use the project namespace for register unit. In the current setup it would use the class name of the plugin, which won't compile.