### PR TITLE
CI: use upstream fix branch, strict, check plugin files

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -67,5 +67,5 @@ after_build:
 - type _install\\TEST_PROJECT_NAME\\TEST_PLUGIN_NAME\\Help\\TEST_PLUGIN_NAME.schelp
 
 - echo "testing existence of plugin files:"
-- exist _install\\TEST_PROJECT_NAME\\TEST_PLUGIN_NAME\\TEST_PLUGIN_NAME_scsynth.scx
-- exist _install\\TEST_PROJECT_NAME\\TEST_PLUGIN_NAME\\TEST_PLUGIN_NAME_supernova.scx
+- if not exist _install\\TEST_PROJECT_NAME\\TEST_PLUGIN_NAME\\TEST_PLUGIN_NAME_scsynth.scx exit 1
+- if not exist _install\\TEST_PROJECT_NAME\\TEST_PLUGIN_NAME\\TEST_PLUGIN_NAME_supernova.scx exit 1

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -65,3 +65,7 @@ after_build:
 
 - echo "schelp file contents:"
 - type _install\\TEST_PROJECT_NAME\\TEST_PLUGIN_NAME\\Help\\TEST_PLUGIN_NAME.schelp
+
+- echo "testing existence of plugin files:"
+- exist _install\\TEST_PROJECT_NAME\\TEST_PLUGIN_NAME\\TEST_PLUGIN_NAME_scsynth.scx
+- exist _install\\TEST_PROJECT_NAME\\TEST_PLUGIN_NAME\\TEST_PLUGIN_NAME_supernova.scx

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -23,7 +23,7 @@ install:
 - python --version
 
 - echo "Get SuperCollider"
-- git clone --depth 1 https://github.com/supercollider/supercollider.git ../supercollider -b cmake-gen-paths
+- git clone --depth 1 https://github.com/supercollider/supercollider.git ../supercollider -b topic/cookie-fixes
 
 - echo "Upgrade pip"
 - python -m pip install --upgrade pip
@@ -54,7 +54,7 @@ before_build:
 - type CMakeLists.txt
 
 - mkdir build && cd build
-- cmake -G "%CMAKE_GENERATOR%" -DCMAKE_INSTALL_PREFIX=_install ..
+- cmake -G "%CMAKE_GENERATOR%" -DCMAKE_INSTALL_PREFIX=_install -DSTRICT=ON ..
 
 build_script:
 - cmake --build . --target install --config %CMAKE_CONFIGURATION%

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,10 @@ matrix:
       sudo: required
       python: "3.6"
       language: python
+      env: PLUGIN_EXT=so
     - os: osx
       language: cpp
+      env: PLUGIN_EXT=scx
 
 before_install:
 - pip3 install cookiecutter
@@ -46,3 +48,7 @@ after_script:
 
 - echo "schelp file contents:"
 - cat _install/TEST_PROJECT_NAME/TEST_PLUGIN_NAME/Help/TEST_PLUGIN_NAME.schelp
+
+- echo "testing existence of plugin files:"
+- [[ -f _install/TEST_PROJECT_NAME/TEST_PLUGIN_NAME/TEST_PLUGIN_NAME_scsynth.$PLUGIN_EXT ]]
+- [[ -f _install/TEST_PROJECT_NAME/TEST_PLUGIN_NAME/TEST_PLUGIN_NAME_supernova.$PLUGIN_EXT ]]

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
 
 before_install:
 - pip3 install cookiecutter
-- git clone --depth 1 https://github.com/supercollider/supercollider.git ../supercollider
+- git clone --depth 1 https://github.com/supercollider/supercollider.git ../supercollider -b topic/cookie-fixes
 
 before_script:
 - cd ..
@@ -35,7 +35,7 @@ before_script:
 - cat CMakeLists.txt
 
 - mkdir build && cd build
-- cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=_install ..
+- cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=_install -DSTRICT=ON ..
 
 script:
 - cmake --build . --target install

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ addons:
     homebrew:
         packages:
         - python3
+    apt:
+        sources:
+        - ubuntu-toolchain-r-test
+        packages:
+        - g++-7
 
 matrix:
     include:
@@ -9,12 +14,17 @@ matrix:
       sudo: required
       python: "3.6"
       language: python
-      env: PLUGIN_EXT=so
+      env:
+      - PLUGIN_EXT=so
+      - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
     - os: osx
       language: cpp
-      env: PLUGIN_EXT=scx
+      env:
+      - PLUGIN_EXT=scx
+      - MATRIX_EVAL=":"
 
 before_install:
+- eval "${MATRIX_EVAL}"
 - pip3 install cookiecutter
 - git clone --depth 1 https://github.com/supercollider/supercollider.git ../supercollider -b topic/cookie-fixes
 


### PR DESCRIPTION
Tighten up CI by using -DSTRICT=ON, pull in fixes from an experimental upstream branch, and
check for the expected existence of installed plugin files when done with build