### PR TITLE
typo in readme

### DIFF
--- a/{{ cookiecutter.repo_name }}/README.md
+++ b/{{ cookiecutter.repo_name }}/README.md
@@ -29,12 +29,12 @@ Then, depending on your toolchain:
     # macOS + Xcode
     cmake .. -GXcode
     cmake --build . --config Release
-    cmake --build . --config Release --target Install
+    cmake --build . --config Release --target install
 
     # Windows + VS 2017
     cmake .. -G"Visual Studio 15 2017 Win64"
     cmake --build . --config Release
-    cmake --build . --config Release --target Install
+    cmake --build . --config Release --target install
 
 You may want to manually specify the install location in the first step to point it at your
 SuperCollider extensions directory: add the option `-DCMAKE_INSTALL_PREFIX=/path/to/extensions`.


### PR DESCRIPTION
The actual target name in the project is called `install`  instead of `Install`.

I could verify on OSX, but don't have a windows machine. Given that this is machine generated the assumption here is, that the windows version also uses the lowercase `install` name.