### PR TITLE
Update readme, format user input

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,18 @@ cookiecutter-supercollider-plugin
 
 A [cookiecutter] project template for [SuperCollider] server plugins.
 
-To create a SuperCollider server plugin using this template, [install cookiecutter][installation
-instructions] and then run:
+To create a SuperCollider server plugin using this template, first
+[install cookiecutter][installation instructions].
+
+**Note**: This cookiecutter template requires a Python version `> 3.2`. If you have multiple
+versions of python and are installing via `pip`, you may need to be explicit about which version
+of Python you use to install it to ensure cookiecutter uses a compatible version. 
+E.g. on macOS:
+```
+python3.7 -m pip install cookiecutter
+```
+
+Then run:
 
     $ cookiecutter https://github.com/supercollider/cookiecutter-supercollider-plugin
 

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -7,7 +7,7 @@ from subprocess import call
 import os
 
 git_url = 'https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.repo_name }}'
-sc_path = '{{ cookiecutter.full_path_to_supercollider_source }}'
+sc_path = '{{ cookiecutter.full_path_to_supercollider_source.strip() }}'
 script_path = os.path.join(sc_path, 'tools/cmake_gen/generate_server_plugin_cmake.py')
 
 print('\nRunning post-project-generation hook...')

--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -5,7 +5,7 @@
 import os
 import sys
 
-sc_path = '{{ cookiecutter.full_path_to_supercollider_source }}'
+sc_path = '{{ cookiecutter.full_path_to_supercollider_source.strip() }}'
 
 print('\nRunning pre-project-generation hook...')
 

--- a/{{ cookiecutter.repo_name }}/README.md
+++ b/{{ cookiecutter.repo_name }}/README.md
@@ -28,12 +28,12 @@ Then, use CMake to configure and build it. Depending on your toolchain:
     # macOS + Xcode
     cmake .. -GXcode
     cmake --build . --config Release
-    cmake --build . --config Release --target Install
+    cmake --build . --config Release --target install
 
     # Windows + VS 2017
     cmake .. -G"Visual Studio 15 2017 Win64"
     cmake --build . --config Release
-    cmake --build . --config Release --target Install
+    cmake --build . --config Release --target install
 
 You may want to manually specify the install location in the first step to point it at your
 SuperCollider extensions directory: add the option `-DCMAKE_INSTALL_PREFIX=/path/to/extensions`.

--- a/{{ cookiecutter.repo_name }}/README.md
+++ b/{{ cookiecutter.repo_name }}/README.md
@@ -11,15 +11,14 @@ Author: {{ cookiecutter.full_name }}
 
 ### Building
 
-Clone the project, then use CMake to configure and build it. If you start from a directory that
-contains the directory where you cloned SuperCollider, the following commands will work.
+Clone the project:
 
     git clone https://{{ cookiecutter.github_username }}/{{ cookiecutter.repo_name }}
     cd {{ cookiecutter.repo_name }}
     mkdir build
     cd build
 
-Then, depending on your toolchain:
+Then, use CMake to configure and build it. Depending on your toolchain:
 
     # Linux + make
     cmake .. -DCMAKE_BUILD_TYPE=Release
@@ -38,6 +37,12 @@ Then, depending on your toolchain:
 
 You may want to manually specify the install location in the first step to point it at your
 SuperCollider extensions directory: add the option `-DCMAKE_INSTALL_PREFIX=/path/to/extensions`.
+
+It's expected that you are running the above commands from the same directory that contains your clone of the SuperCollider source, called `supercollider`.
+If you are running `cmake` from a different directory, or if your SuperCollider source directory is not named `supercollider`, add its path when setting up the project, e.g. for macOS:
+```
+cmake .. -DSC_PATH=/Path/to/sc/source -GXcode`
+```
 
 ### Developing
 


### PR DESCRIPTION

This repo's `README`:
- Adds notes regarding potential python version conflict.

Cookiecutter-generated `README`:
- Clarify sc source path for non-standard install locations.
- `install` target should be lowercase **Tested on Mac—please confirm on Windows**

Hooks:
- Strip leading/trailing whitespace from SC path. This is a gotcha when drag-and-dropping Sc’s path into the questionnaire.