### PR TITLE
cpp template: call make_calc_fuction instead of set_calc_function.

### DIFF
--- a/{{ cookiecutter.repo_name }}/plugins/{{ cookiecutter.plugin_name }}/{{ cookiecutter.plugin_name }}.cpp
+++ b/{{ cookiecutter.repo_name }}/plugins/{{ cookiecutter.plugin_name }}/{{ cookiecutter.plugin_name }}.cpp
@@ -10,7 +10,7 @@ namespace {{ cookiecutter.project_namespace }} {
 
 {{ cookiecutter.plugin_name }}::{{ cookiecutter.plugin_name }}()
 {
-    set_calc_function<{{ cookiecutter.plugin_name }}, &{{ cookiecutter.plugin_name }}::next>();
+    mCalcFunc = make_calc_function<{{ cookiecutter.plugin_name }}, &{{ cookiecutter.plugin_name }}::next>();
     next(1);
 }
 


### PR DESCRIPTION
`set_calc_function` currently calls `next(1)` internally, which has been
[discussed](https://github.com/supercollider/example-plugins/issues/8) and looks slated to be changed. 

In the meantime, to avoid calling `next(1)` twice, and to be explicit in the 
template that an initialization sample needs to be set, setting `mCalcFunc` 
directly with `make_calc_fuction` and then calling `next(1)` is a better model.