### PR TITLE
MacOS fix: python not found (deprecated in favour of python3)

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 '''Init git repository and make initial commit.'''
 
@@ -16,7 +16,7 @@ print('\nInitializing new Git repository')
 check_call(['git', 'init'])
 print('\nRunning CMake generation script')
 call([
-    'python',
+    'python3',
     script_path,
     '.',
     '-P', '{{ cookiecutter.project_name }}',

--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 '''Validate template arguments.'''
 

--- a/{{ cookiecutter.repo_name }}/regenerate
+++ b/{{ cookiecutter.repo_name }}/regenerate
@@ -1,1 +1,1 @@
-python {{ cookiecutter.full_path_to_supercollider_source }}/tools/cmake_gen/generate_server_plugin_cmake.py -P "{{ cookiecutter.project_name }}" -p "plugins/{{ cookiecutter.plugin_name }}" -a "{{ cookiecutter.full_name }}"
+python3 {{ cookiecutter.full_path_to_supercollider_source }}/tools/cmake_gen/generate_server_plugin_cmake.py -P "{{ cookiecutter.project_name }}" -p "plugins/{{ cookiecutter.plugin_name }}" -a "{{ cookiecutter.full_name }}"


### PR DESCRIPTION
This fixes #33 

The `python` executable no longer works on modern MacOS because it has been deprecated in favour of `python3`. This makes cookiecutter fail because it specifically tries to call `python` in the cmake generation script.

Before merging: Will this work universally on Linux machines as well?

