### PR TITLE
Use latest OS tag. Use checkout@v3. Add permissions section.

### DIFF
--- a/{{ cookiecutter.repo_name }}/.github/workflows/pluginbuild.yml
+++ b/{{ cookiecutter.repo_name }}/.github/workflows/pluginbuild.yml
@@ -5,21 +5,22 @@ on:
 
 jobs:
   build:
-
     runs-on: {{"${{"}} matrix.os {{"}}"}}
     name: {{"${{"}} matrix.name {{"}}"}}
+#   You may need to uncomment this part if using granular workflows.
+#   permissions:
+#     content: write
     strategy:
       matrix:
         include:
-
           - name: macOS
-            os: macos-10.15
+            os: macos-latest
 
           - name: Linux-x64
-            os: ubuntu-18.04
+            os: ubuntu-latest
 
           - name: Windows-x64
-            os: windows-2019
+            os: windows-latest
 
     env:
       SC_PATH: {{"${{"}} github.workspace {{"}}"}}/supercollider
@@ -28,10 +29,10 @@ jobs:
       ARCHIVE_NAME: {{cookiecutter.plugin_name}}-{{"${{"}} matrix.name {{"}}"}}.zip
     steps:
     - name: Checkout {{cookiecutter.plugin_name}}
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Checkout SuperCollider
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: supercollider/supercollider
         path: {{"${{"}} env.SC_PATH {{"}}"}}


### PR DESCRIPTION
I found these changes to be helpful in a repo of mine.

I found the permissions to be necessary by default, but I'm not confident everyone needs this.
GitHub apparently is quicker to assign runners to the more recent OS versions, and this seemed more future-proof to me.
Checkout action has a new version, seems to be compatible with the options previously given.